### PR TITLE
Multiple trusted forwarders

### DIFF
--- a/contracts/GaugeUpkeepManager.sol
+++ b/contracts/GaugeUpkeepManager.sol
@@ -22,11 +22,11 @@ contract GaugeUpkeepManager is IGaugeUpkeepManager, ILogAutomation, Ownable {
     address public immutable override voter;
 
     /// @inheritdoc IGaugeUpkeepManager
-    address public override trustedForwarder;
-    /// @inheritdoc IGaugeUpkeepManager
     uint96 public override newUpkeepFundAmount;
     /// @inheritdoc IGaugeUpkeepManager
     uint32 public override newUpkeepGasLimit;
+    /// @inheritdoc IGaugeUpkeepManager
+    mapping(address => bool) public override trustedForwarder;
 
     /// @inheritdoc IGaugeUpkeepManager
     mapping(address => uint256) public override gaugeUpkeepId;
@@ -103,7 +103,7 @@ contract GaugeUpkeepManager is IGaugeUpkeepManager, ILogAutomation, Ownable {
     /// @notice Perform the upkeep action according to the performData passed from checkUpkeep/checkLog
     /// @dev This function is called by the automation network to perform the upkeep action
     function performUpkeep(bytes calldata performData) external override(ILogAutomation) {
-        if (msg.sender != trustedForwarder) {
+        if (!trustedForwarder[msg.sender]) {
             revert UnauthorizedSender();
         }
         (PerformAction action, address gauge) = abi.decode(performData, (PerformAction, address));
@@ -192,7 +192,7 @@ contract GaugeUpkeepManager is IGaugeUpkeepManager, ILogAutomation, Ownable {
     }
 
     /// @inheritdoc IGaugeUpkeepManager
-    function setTrustedForwarder(address _trustedForwarder) external override onlyOwner {
-        trustedForwarder = _trustedForwarder;
+    function setTrustedForwarder(address _trustedForwarder, bool _isTrusted) external override onlyOwner {
+        trustedForwarder[_trustedForwarder] = _isTrusted;
     }
 }

--- a/contracts/interfaces/IGaugeUpkeepManager.sol
+++ b/contracts/interfaces/IGaugeUpkeepManager.sol
@@ -21,14 +21,14 @@ interface IGaugeUpkeepManager {
     /// @notice Voter address
     function voter() external view returns (address);
 
-    /// @notice Automation trusted forwarder address
-    function trustedForwarder() external view returns (address);
-
     /// @notice Amount of LINK to transfer to upkeep on registration
     function newUpkeepFundAmount() external view returns (uint96);
 
     /// @notice Gas limit for new upkeeps
     function newUpkeepGasLimit() external view returns (uint32);
+
+    /// @notice Weather an address is a trusted forwarder
+    function trustedForwarder(address) external view returns (bool);
 
     /// @notice Upkeep ID for a gauge
     function gaugeUpkeepId(address gauge) external view returns (uint256);
@@ -56,5 +56,6 @@ interface IGaugeUpkeepManager {
 
     /// @notice Set the automation trusted forwarder address
     /// @param trustedForwarder Upkeep trusted forwarder address
-    function setTrustedForwarder(address trustedForwarder) external;
+    /// @param isTrusted True to enable trusted forwarder, false to disable
+    function setTrustedForwarder(address trustedForwarder, bool isTrusted) external;
 }


### PR DESCRIPTION
- Each gauge event log trigger (created/killed/revived) is its own upkeep
- Each upkeep has a unique trusted forwarder
- Perform upkeep must allow only trusted forwarders to execute